### PR TITLE
[iTrace-3] get union between uc/code, rtm and ri rather than uc/code and rtm

### DIFF
--- a/src/cn/edu/nju/cs/itrace4/exp/gantt/preprogress/PreprocessTextGantt.java
+++ b/src/cn/edu/nju/cs/itrace4/exp/gantt/preprogress/PreprocessTextGantt.java
@@ -1,6 +1,10 @@
 package cn.edu.nju.cs.itrace4.exp.gantt.preprogress;
 
+import java.io.IOException;
+import java.util.HashSet;
+
 import cn.edu.nju.cs.itrace4.core.type.Granularity;
+import cn.edu.nju.cs.itrace4.exp.tool.PruneBaseRI;
 import cn.edu.nju.cs.itrace4.parser.SourceTargetUnion;
 import cn.edu.nju.cs.itrace4.preprocess.BatchingPreprocess;
 import cn.edu.nju.cs.itrace4.relation.RelationInfo;
@@ -19,13 +23,14 @@ public class PreprocessTextGantt {
 
     private static String relationDirPath = "data/exp/Gantt/relation";
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         SourceTargetUnion union = new SourceTargetUnion(ucDirPath, srcDirPath, rtmDBFilePath, Granularity.CLASS,classDirPath,methodDirPath);
 
         BatchingPreprocess preprocess = new BatchingPreprocess(ucDirPath, classDirPath, methodDirPath);
         preprocess.doProcess();
 
         RelationInfo rg = new RelationInfo(classDirPath, relationDirPath, Granularity.CLASS);
+        PruneBaseRI.pruneBaseRT("./data/exp/Gantt", new HashSet<String>(rg.getVertexIdNameMap().values()));
         rg.showMessage();
     }
 }

--- a/src/cn/edu/nju/cs/itrace4/exp/infinispan/preprocess/PreprocessTextInfinispan.java
+++ b/src/cn/edu/nju/cs/itrace4/exp/infinispan/preprocess/PreprocessTextInfinispan.java
@@ -92,7 +92,7 @@ public class PreprocessTextInfinispan {
         BatchingPreprocess preprocess = new BatchingPreprocess(ucDirPath, classDirPath, methodDirPath);
         preprocess.doProcess();
         
-        System.setProperty("projectType", "git");
+        //System.setProperty("projectType", "git");
         RelationInfo rg = new RelationInfo(classDirPath, relationDirPath, Granularity.CLASS);
         rg.showMessage();
     }

--- a/src/cn/edu/nju/cs/itrace4/exp/itrust/preprocess/PreprocessTextITrust.java
+++ b/src/cn/edu/nju/cs/itrace4/exp/itrust/preprocess/PreprocessTextITrust.java
@@ -1,6 +1,10 @@
 package cn.edu.nju.cs.itrace4.exp.itrust.preprocess;
 
+import java.io.IOException;
+import java.util.HashSet;
+
 import cn.edu.nju.cs.itrace4.core.type.Granularity;
+import cn.edu.nju.cs.itrace4.exp.tool.PruneBaseRI;
 import cn.edu.nju.cs.itrace4.parser.SourceTargetUnion;
 import cn.edu.nju.cs.itrace4.preprocess.BatchingPreprocess;
 import cn.edu.nju.cs.itrace4.relation.RelationInfo;
@@ -19,13 +23,14 @@ public class PreprocessTextITrust {
 
     private static String relationDirPath = "data/exp/iTrust/relation";
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         SourceTargetUnion union = new SourceTargetUnion(ucDirPath, srcDirPath, rtmDBFilePath, Granularity.CLASS,classDirPath,methodDirPath);
 
         BatchingPreprocess preprocess = new BatchingPreprocess(ucDirPath, classDirPath, methodDirPath);
         preprocess.doProcess();
 
         RelationInfo rg = new RelationInfo(classDirPath, relationDirPath, Granularity.CLASS);
+        PruneBaseRI.pruneBaseRT("./data/exp/iTrust", new HashSet<String>(rg.getVertexIdNameMap().values()));
         rg.showMessage();
     }
 }

--- a/src/cn/edu/nju/cs/itrace4/exp/maven/preprocess/PreprocessTextMaven.java
+++ b/src/cn/edu/nju/cs/itrace4/exp/maven/preprocess/PreprocessTextMaven.java
@@ -1,10 +1,13 @@
 package cn.edu.nju.cs.itrace4.exp.maven.preprocess;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
 
 import cn.edu.nju.cs.itrace4.core.type.Granularity;
 import cn.edu.nju.cs.itrace4.exp.tool.GetSrc;
 import cn.edu.nju.cs.itrace4.exp.tool.GetUC;
+import cn.edu.nju.cs.itrace4.exp.tool.PruneBaseRI;
 import cn.edu.nju.cs.itrace4.exp.tool.RTMProcess;
 import cn.edu.nju.cs.itrace4.exp.tool.TransferTXT;
 import cn.edu.nju.cs.itrace4.parser.SourceTargetUnion;
@@ -75,7 +78,7 @@ public class PreprocessTextMaven {
 		}
     }
     
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         /*
          * @author zzf <tiaozhanzhe668@163.com>
          * @date 2017/10/11
@@ -84,13 +87,15 @@ public class PreprocessTextMaven {
     	PreprocessTextMaven MavenProcess = new PreprocessTextMaven(rtmDBFilePath);
     	MavenProcess.cleanData();
     	MavenProcess.arrangeData();
+    	
     	SourceTargetUnionForGit union = new SourceTargetUnionForGit(ucDirPath, srcDirPath, rtmDBFilePath, Granularity.CLASS,classDirPath,methodDirPath);
 
         BatchingPreprocess preprocess = new BatchingPreprocess(ucDirPath, classDirPath, methodDirPath);
         preprocess.doProcess();
         
-        System.setProperty("projectType", "git");
+        //System.setProperty("projectType", "git");
         RelationInfo rg = new RelationInfo(classDirPath, relationDirPath, Granularity.CLASS);
+        PruneBaseRI.pruneBaseRT("./data/exp/Maven", new HashSet<String>(rg.getVertexIdNameMap().values()));
         rg.showMessage();
     }
 	

--- a/src/cn/edu/nju/cs/itrace4/exp/tool/PruneBaseRI.java
+++ b/src/cn/edu/nju/cs/itrace4/exp/tool/PruneBaseRI.java
@@ -1,0 +1,90 @@
+package cn.edu.nju.cs.itrace4.exp.tool;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author zzf
+ * @date 2017.11.12
+ * @description prune RTM based on ri, About class in RTM, if it not appear in ri,delete it.
+ *  Then as soon as the RTM change. Then we need to prune code/uc based rtm
+ */
+public class PruneBaseRI {
+	public static void pruneBaseRT(String basePath,Set<String> riClassSet) throws IOException {
+		String rtmPath = basePath+File.separator+
+				"rtm"+File.separator+"RTM_CLASS.txt";
+		BufferedReader br = new BufferedReader(new FileReader(rtmPath));
+		StringBuilder sb = new StringBuilder();
+		String line = null;
+		while((line=br.readLine())!=null) {
+			String className = line.split("\\s+")[1];
+			if(riClassSet.contains(className)) {
+				sb.append(line+"\n");
+			}
+			else {
+				System.out.println("************  "+className+"  not in ri **************");
+			}
+		}
+		br.close();
+		writeToFile(rtmPath,sb.toString());
+		//prune code/uc based on rtm
+		String ucPath = basePath + File.separator + "uc";
+		String codePath = basePath + File.separator + "class" + File.separator + "code";
+		/**
+		 * rtm line example: UC4 SearchUsersAction 1.0
+		 * the first element in line represent uc, the second represent class name. 
+		 */
+		deleteNotInRTM(ucPath,rtmPath,0);
+		deleteNotInRTM(codePath,rtmPath,1);
+	}
+
+	private static void deleteNotInRTM(String path, String rtmPath, int index) {
+		Set<String> nameSet = null;
+		try {
+			nameSet = getNameSet(rtmPath,index);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		File dir = new File(path);
+		File[] files = dir.listFiles();
+		for(File file:files) {
+			String fileFullName = file.getName();
+			String fileName = fileFullName.substring(0,fileFullName.lastIndexOf("."));
+			if(!nameSet.contains(fileName)) {
+				file.delete();
+			}
+		}
+	}
+
+	private static Set<String> getNameSet(String rtmPath, int index) throws Exception {
+		Set<String> set = new HashSet<String>();
+		BufferedReader br = new BufferedReader(new FileReader(rtmPath));
+		String line;
+		while((line=br.readLine())!=null) {
+			set.add(line.split("\\s+")[index]);
+		}
+		br.close();
+		return set;
+	}
+
+	private static void writeToFile(String rtmPath, String content) throws IOException {
+		BufferedWriter bw = new BufferedWriter(new FileWriter(rtmPath));
+		bw.write(content);
+		bw.close();
+	}
+}
+
+
+
+
+
+
+
+

--- a/src/cn/edu/nju/cs/itrace4/exp/tool/RTMProcess.java
+++ b/src/cn/edu/nju/cs/itrace4/exp/tool/RTMProcess.java
@@ -66,6 +66,12 @@ public class RTMProcess {
 			for(int id:subGraph) {
 				String issueId = idMapName.get(id);
 				ResultSet rs = stmt.executeQuery(sql+"'"+issueId+"'");
+				/**
+				 * issueId may not in init_rtm 
+				 */
+				if(!rs.next()) {
+					continue;
+				}
 				visited.add(rs.getString("issue_id").trim());
 				request.append(rs.getString("request")+" ");
 				code.append(rs.getString("file_path")+"和");


### PR DESCRIPTION
Ensure all class in rtm has appeared in RI. Add class *PruneBaseRI* to achieve this function.

use example:
    public static void main(String[] args) throws IOException {
        ...
        PruneBaseRI.pruneBaseRT("./data/exp/iTrust", new HashSet<String>(rg.getVertexIdNameMap().values()));
        ...
}

the first parameter give *path* of *project* and the second give the class name in ri.