### PR TITLE
[iTrace-4] calculate the distance of region from a specify valid region

### DIFF
--- a/resource/config.xml
+++ b/resource/config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-	<projectName>iTrust</projectName>
+	<projectName>infinispan</projectName>
 	<modelName>vsm</modelName>
-	<callEdgeScoreThreshold>0.6</callEdgeScoreThreshold>
-	<dataEdgeScoreThreshold>0.7</dataEdgeScoreThreshold>
+	<callEdgeScoreThreshold>0.5</callEdgeScoreThreshold>
+	<dataEdgeScoreThreshold>0.5</dataEdgeScoreThreshold>
 	<percent>0.5</percent>
 	<router>6</router>
 </config>

--- a/src/cn/edu/nju/cs/itrace4/demo/algo/SortBySubGraph.java
+++ b/src/cn/edu/nju/cs/itrace4/demo/algo/SortBySubGraph.java
@@ -47,6 +47,8 @@ public class SortBySubGraph implements Comparator<SubGraph>{
 		int maxId = sub1.getVertexList().get(0);
 		List<Integer> vertexList = sub1.getVertexList();
 		for(int i = 0; i<vertexList.size(); i++){
+			System.out.println(vertexList.get(i));
+			System.out.println(vertexIdNameMap.get(vertexList.get(i)));
 			double curScore = matrix.getScoreForLink(target,vertexIdNameMap.get(vertexList.get(i)));
 			maxScore = Math.max(maxScore, curScore);
 			if(Math.abs(curScore-maxScore)<=0.000000000001){

--- a/src/cn/edu/nju/cs/itrace4/demo/algo/outerVertex/process/UD_CallSubGraphWithBonusForLone.java
+++ b/src/cn/edu/nju/cs/itrace4/demo/algo/outerVertex/process/UD_CallSubGraphWithBonusForLone.java
@@ -401,7 +401,6 @@ public class UD_CallSubGraphWithBonusForLone implements CSTI{
 				 * @description use local max
 				 **/
 				int localMaxId = subGraph.getMaxId();
-				double localMaxScore = matrix.getScoreForLink(req, vertexIdNameMap.get(localMaxId));
 				
 				////////////////////////////////////////////////////////////////////////////////////
 				
@@ -412,7 +411,6 @@ public class UD_CallSubGraphWithBonusForLone implements CSTI{
 				}
 				
 				//regard the max score in this subGraph as represent
-				int localMaxId = subGraph.getMaxId();
 				String represent = vertexIdNameMap.get(localMaxId);
 				double representValue = matrix.getScoreForLink(req, represent);
 				double maxScoreInThisSubGraph = representValue;
@@ -451,15 +449,7 @@ public class UD_CallSubGraphWithBonusForLone implements CSTI{
 						double curValue = matrix.getScoreForLink(req, vertexName);
 						if(!vertexName.equals(represent)){
 							int graphSize = subGraph.getVertexList().size();
-<<<<<<< HEAD
-							
-							double originValue = curValue;
-							curValue = Math.min(maxScore, curValue+maxScore/(graphSize-1));
-							//curValue = Math.min(localMaxScore, curValue+localMaxScore/(graphSize-1));
-							minInnerBonus = Math.min(minInnerBonus, curValue-originValue);
-=======
 							curValue = Math.min(maxScore*0.9999, curValue+maxScore/(graphSize-1));
->>>>>>> master
 							maxScoreInThisSubGraph = Math.max(maxScoreInThisSubGraph, curValue);
 						}
 						matrix_ud.addLink(req, vertexName,curValue);

--- a/src/cn/edu/nju/cs/itrace4/demo/exp/project/Infinispan.java
+++ b/src/cn/edu/nju/cs/itrace4/demo/exp/project/Infinispan.java
@@ -12,7 +12,6 @@ public class Infinispan implements Project{
 	public String jsExpExportPath_ICSME = "data/exp/Infinispan/icsme_result/js";
 	public String lsiExpExportPath_ICSME = "data/exp/Infinispan/icsme_result/lsi";
 	public String projectName = "Infinispan";
-	
 	public String getProjectPath() {
 		return projectPath;
 	}
@@ -36,10 +35,10 @@ public class Infinispan implements Project{
 	public String getClassDirPath() {
 		return classDirPath;
 	}
-	
 	@Override
 	public String getClass_RelationInfoPath() {
-		return class_relationInfoPath;
+		//return class_relationInfoPath;
+		return class_relationInfoPathWhole;
 	}
 	
 	@Override

--- a/src/cn/edu/nju/cs/itrace4/demo/exp/project/Maven.java
+++ b/src/cn/edu/nju/cs/itrace4/demo/exp/project/Maven.java
@@ -39,7 +39,8 @@ public class Maven implements Project{
 	
 	@Override
 	public String getClass_RelationInfoPath() {
-		return class_relationInfoPath;
+		//return class_relationInfoPath;
+		return class_relationInfoPathWhole;
 	}
 	
 	@Override

--- a/src/cn/edu/nju/cs/itrace4/demo/explore/BootForRegionRelation.java
+++ b/src/cn/edu/nju/cs/itrace4/demo/explore/BootForRegionRelation.java
@@ -1,0 +1,86 @@
+package cn.edu.nju.cs.itrace4.demo.explore;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.xml.sax.SAXException;
+
+import cn.edu.nju.cs.itrace4.core.algo.None_CSTI;
+import cn.edu.nju.cs.itrace4.core.dataset.TextDataset;
+import cn.edu.nju.cs.itrace4.core.ir.IR;
+import cn.edu.nju.cs.itrace4.core.metrics.Result;
+import cn.edu.nju.cs.itrace4.demo.FileParse.XmlParse;
+import cn.edu.nju.cs.itrace4.demo.exp.project.Gantt;
+import cn.edu.nju.cs.itrace4.demo.exp.project.Infinispan;
+import cn.edu.nju.cs.itrace4.demo.exp.project.Itrust;
+import cn.edu.nju.cs.itrace4.demo.exp.project.JhotDraw;
+import cn.edu.nju.cs.itrace4.demo.exp.project.Maven;
+import cn.edu.nju.cs.itrace4.demo.exp.project.Project;
+import cn.edu.nju.cs.itrace4.relation.RelationInfo;
+
+public class BootForRegionRelation {
+	//private StoreSubGraphInfoByThreshold storeSubGraphInfoByThreshold;
+		private Project project;
+		private String model;
+		private Map<String,Project> projectMap = new HashMap<String,Project>();
+		private Map<String,String> modelMap = new HashMap<String,String>();
+		private XmlParse xmlParse; 
+		private double callEdgeScoreThreshold;
+	    private double dataEdgeScoreThreshold;
+	    
+		public BootForRegionRelation() throws ParserConfigurationException, SAXException, IOException{
+			initProjectMap();
+			initModelMap();
+			xmlParse = new XmlParse();
+			//read xml
+			String[] res = xmlParse.process();
+			project = projectMap.get(res[0]);
+			model = modelMap.get(res[1]);
+			callEdgeScoreThreshold = Double.valueOf(res[2]);
+			dataEdgeScoreThreshold = Double.valueOf(res[3]);
+			System.setProperty("routerLen", Integer.valueOf(res[5])+"");
+		}
+		
+		private void initModelMap(){
+			modelMap.put("vsm","cn.edu.nju.cs.itrace4.core.ir.VSM");
+			modelMap.put("jsd", "cn.edu.nju.cs.itrace4.core.ir.JSD");
+			modelMap.put("lsi", "cn.edu.nju.cs.itrace4.core.ir.LSI");
+		} 
+		
+		private void initProjectMap() {
+			projectMap.put("itrust", new Itrust());
+			projectMap.put("gantt", new Gantt());
+			projectMap.put("jhotdraw", new JhotDraw());
+			projectMap.put("maven", new Maven());
+			projectMap.put("infinispan", new Infinispan());
+		}
+
+
+		public void run() throws IOException, ClassNotFoundException {
+	        TextDataset textDataset = new TextDataset(project.getUcPath(), project.getClassDirPath(), 
+	        		project.getRtmClassPath());
+
+	        FileInputStream fis = new FileInputStream(project.getClass_RelationInfoPath());
+	        ObjectInputStream ois = new ObjectInputStream(fis);
+	        RelationInfo ri = (RelationInfo) ois.readObject();
+	        ois.close();
+	        Result result_ir = IR.compute(textDataset, model, new None_CSTI());
+	        ri.setPruning(callEdgeScoreThreshold, dataEdgeScoreThreshold);
+	        RelationBetweenRegion relationBetweenRegion = new RelationBetweenRegion(ri);
+	        relationBetweenRegion.getRelationBetweenRegion(result_ir.getMatrix(), textDataset);
+	    }
+
+		public static void main(String[] args) throws IOException, ClassNotFoundException,
+				ParserConfigurationException, SAXException {
+			long startTime = System.currentTimeMillis();
+	    	BootForRegionRelation bonusForLoneBoot = new BootForRegionRelation();
+	    	bonusForLoneBoot.run();
+	    	long endTime = System.currentTimeMillis();
+	    	System.out.println("time cost:"+(endTime-startTime)*1.0/1000/60);
+	    }
+}

--- a/src/cn/edu/nju/cs/itrace4/demo/explore/RelationBetweenRegion.java
+++ b/src/cn/edu/nju/cs/itrace4/demo/explore/RelationBetweenRegion.java
@@ -1,0 +1,260 @@
+package cn.edu.nju.cs.itrace4.demo.explore;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import cn.edu.nju.cs.itrace4.core.dataset.TextDataset;
+import cn.edu.nju.cs.itrace4.core.document.LinksList;
+import cn.edu.nju.cs.itrace4.core.document.SimilarityMatrix;
+import cn.edu.nju.cs.itrace4.core.document.SingleLink;
+import cn.edu.nju.cs.itrace4.demo.algo.SortBySubGraph;
+import cn.edu.nju.cs.itrace4.demo.algo.SortVertexByScore;
+import cn.edu.nju.cs.itrace4.demo.relation.StoreCallSubGraph;
+import cn.edu.nju.cs.itrace4.demo.relation.StoreDataSubGraph;
+import cn.edu.nju.cs.itrace4.demo.relation.SubGraph;
+import cn.edu.nju.cs.itrace4.relation.CallDataRelationGraph;
+import cn.edu.nju.cs.itrace4.relation.RelationInfo;
+import cn.edu.nju.cs.itrace4.relation.graph.CodeEdge;
+
+/**
+ * @author zzf
+ * @date 2017.11.13
+ * @description get relation between valid region and valid region or no valid region
+ * 		step1: get region based on call/data threshold
+ *      step2: find the first region
+ *      step3: calculate the distance of from this valid region and other valid region or no valid region
+ */
+public class RelationBetweenRegion {
+	
+	private double[][] callGraphs;
+	private double[][] dataGraphs;
+	
+	private List<SubGraph> callSubGraphList;
+	private List<SubGraph> dataSubGraphList;
+	private List<SubGraph> callDataSubGraphList;
+	
+	protected Map<Integer, String> vertexIdNameMap;
+	
+	private int countThreshold = 2;
+	private int routerLen = 1;
+	
+	public RelationBetweenRegion(RelationInfo ri) {
+		callSubGraphList = new StoreCallSubGraph().getSubGraphs(ri);
+		dataSubGraphList = new StoreDataSubGraph().getSubGraphs(ri);
+		callDataSubGraphList = mergeSubGraphList(callSubGraphList,dataSubGraphList);
+		
+		callGraphs = describeCallGraphWithMatrix(new CallDataRelationGraph(ri).callEdgeScoreMap,ri.getVertexes().size());
+		dataGraphs = describeDataGraphWithMatrix(new CallDataRelationGraph(ri).dataEdgeScoreMap,ri.getVertexes().size());
+		vertexIdNameMap = ri.getVertexIdNameMap();
+	}
+	
+	
+	public void getRelationBetweenRegion(SimilarityMatrix matrix, TextDataset textDataset){
+		 SimilarityMatrix oracle = textDataset.getRtm();
+		 //get all target artifacts
+		 removeLoneVertexList(callDataSubGraphList);
+		 for(String req:textDataset.getSourceCollection().keySet()){
+			//it will get maxId for every subGraph after sort.
+			Collections.sort(callDataSubGraphList,new SortBySubGraph(vertexIdNameMap,matrix,req));
+			int firstValidIndex = getFirstValidRegionIndex(req,callDataSubGraphList,oracle);
+			System.out.println("*****************"+req+"******************* "+firstValidIndex);
+			if(firstValidIndex==-1) {
+				continue;
+			}
+			
+			SubGraph target = callDataSubGraphList.get(firstValidIndex);
+			for(int i = firstValidIndex+1; i<callDataSubGraphList.size(); i++) {
+				SubGraph subGraph = callDataSubGraphList.get(i);
+				boolean valid = isValidRegion(req,subGraph,oracle);
+				double distance = distanceBetweenRegion(subGraph,target);
+				if(distance!=0) {
+					System.out.println(valid+" : "+distance);
+				}
+			}
+		 }
+		
+	}
+	
+	private double distanceBetweenRegion(SubGraph subGraph, SubGraph target) {
+		double maxValue = -1;
+		for(int id:subGraph.getVertexList()) {
+			double curValue = giveBonusForLonePointBasedCallGraph(callGraphs,target,id,1);
+			maxValue = Math.max(maxValue, curValue);
+		}
+		return maxValue;
+	}
+
+	private double giveBonusForLonePointBasedCallGraph(double[][] graphs, SubGraph subGraph, int loneVertex,
+			double diffBetweenTopAndCur) {
+		double maxBonus = 0;
+		for (int vertex : subGraph.getVertexList()) {
+			List<List<Integer>> allRoutes = new LinkedList<List<Integer>>();
+			List<Integer> curRoute = new LinkedList<Integer>();
+			Set<Integer> vertexInGraph = new HashSet<Integer>(subGraph.getVertexList());
+			Set<Integer> visited = new HashSet<Integer>();
+			visited.add(loneVertex);
+			curRoute.add(loneVertex);
+			getAllRoutesFromOuterToInnerByDfs(graphs, loneVertex, curRoute, allRoutes, vertexInGraph, visited, vertex);
+			getAllRoutesFromInnerToOuterByDfs(graphs, loneVertex, curRoute, allRoutes, vertexInGraph, visited, vertex);
+			double curMaxBonus = 0;
+			for (List<Integer> route : allRoutes) {
+				double geometryMean = geometricMean(graphs, route);//
+				curMaxBonus = Math.max(curMaxBonus, geometryMean);
+			}
+
+			maxBonus = Math.max(maxBonus, curMaxBonus);
+		}
+		return maxBonus;
+	}
+
+	private double geometricMean(double[][] graphs, List<Integer> route) {
+		if(route.size()==0){
+			return 0;
+		}
+		double res = 1;
+		int[] routes = new int[route.size()];
+		int index = 0;
+		for(int ele:route){
+			routes[index++] = ele;
+		}
+		for(int i = 1; i < routes.length;i++){
+			int one = routes[i];
+			int other = routes[i-1];
+			if(graphs[one][other]!=0){
+				//base += 1.0/graphs[one][other];
+				res *= graphs[one][other];
+			}
+			else{
+				//base += 1.0/graphs[other][one];
+				res *= graphs[other][one];
+			}
+		}
+		//double geometryMean = Math.pow(res, 1.0/(routes.length-1));
+		double geometryMean = Math.pow(res, 1.0/(1));
+		//double geometryMean = count / base;
+		return geometryMean;
+	}
+	
+	private void getAllRoutesFromInnerToOuterByDfs(double[][] graphs, int curVertex, List<Integer> curRoute,List<List<Integer>> allRoutes,
+			Set<Integer> vertexInGraph, Set<Integer> visited, int target) {
+		 if(curVertex==target){
+	            allRoutes.add(new LinkedList<Integer>(curRoute));
+	     }
+	     else if(vertexInGraph.contains(curVertex)||curRoute.size()==routerLen){
+	            return ;
+	     }
+	     else{
+	        	//from outer to inner
+	            for(int i = 1; i < graphs.length;i++){
+	            	if(graphs[i][curVertex]==0||visited.contains(i)){
+	            		continue;
+	            	}
+	                visited.add(i);
+	                curRoute.add(i);
+	                getAllRoutesFromInnerToOuterByDfs(graphs,i,curRoute,allRoutes,vertexInGraph,visited,target);
+	                curRoute.remove(curRoute.size()-1);
+	                visited.remove(i);
+	            }
+	     }
+	}
+
+	
+	private void getAllRoutesFromOuterToInnerByDfs(double[][] graphs, int curVertex, List<Integer> curRoute,List<List<Integer>> allRoutes,
+			Set<Integer> vertexInGraph, Set<Integer> visited, int target) {
+		 if(curVertex==target){
+	            allRoutes.add(new LinkedList<Integer>(curRoute));
+	     }
+	     else if(vertexInGraph.contains(curVertex)||curRoute.size()==routerLen){
+	            return ;
+	     }
+	     else{
+	        	//from outer to inner
+	            for(int i = 1; i < graphs.length;i++){
+	            	if(graphs[curVertex][i]==0||visited.contains(i)){
+	            		continue;
+	            	}
+	                visited.add(i);
+	                curRoute.add(i);
+	                getAllRoutesFromOuterToInnerByDfs(graphs,i,curRoute,allRoutes,vertexInGraph,visited,target);
+	                curRoute.remove(curRoute.size()-1);
+	                visited.remove(i);
+	            }
+	     }
+	}
+	
+	
+
+	private boolean isValidRegion(String req, SubGraph subGraph, SimilarityMatrix oracle) {
+		int localMaxId = subGraph.getMaxId();
+		String className = vertexIdNameMap.get(localMaxId);
+		if(oracle.isLinkAboveThreshold(req, className)) {
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+
+	private int getFirstValidRegionIndex(String req,List<SubGraph> callDataSubGraphList, SimilarityMatrix oracle) {
+		for(int i = 0; i < callDataSubGraphList.size();i++) {
+			SubGraph subGraph = callDataSubGraphList.get(i);
+			int curMaxId = subGraph.getMaxId();
+			String curName = vertexIdNameMap.get(curMaxId);
+			if(oracle.isLinkAboveThreshold(req, curName)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private void removeLoneVertexList(List<SubGraph> callDataSubGraphList) {
+		Iterator<SubGraph> ite = callDataSubGraphList.iterator();
+		while(ite.hasNext()) {
+			SubGraph subGraph = ite.next();
+			if(subGraph.getVertexList().size()<countThreshold) {
+				ite.remove();
+			}
+		}
+	}
+
+	private List<SubGraph> mergeSubGraphList(List<SubGraph> callSubGraphList,
+			List<SubGraph> dataSubGraphList) {
+		List<SubGraph> callDataSubGraphList = new LinkedList<SubGraph>();
+		callDataSubGraphList.addAll(callSubGraphList);
+		callDataSubGraphList.addAll(dataSubGraphList);
+		return callDataSubGraphList;
+	}
+
+
+	private double[][] describeDataGraphWithMatrix(Map<CodeEdge, Double> dataEdgeScoreMap, int size) {
+		double[][] matrix = new double[size+1][size+1];
+		for(CodeEdge edge:dataEdgeScoreMap.keySet()){
+			int callerId = edge.getSource().getId();
+			int calleeId = edge.getTarget().getId();
+			double score = dataEdgeScoreMap.get(edge);
+			matrix[callerId][calleeId] = score;
+			matrix[calleeId][callerId] = score;
+		}
+		return matrix;
+	}
+
+
+	private double[][] describeCallGraphWithMatrix(Map<CodeEdge, Double> callEdgeScoreMap, int size) {
+		double[][] matrix = new double[size+1][size+1];
+		for(CodeEdge edge:callEdgeScoreMap.keySet()){
+			int callerId = edge.getSource().getId();
+			int calleeId = edge.getTarget().getId();
+			double score = callEdgeScoreMap.get(edge);
+			matrix[callerId][calleeId] = score;
+		}
+		return matrix;
+	}
+}

--- a/src/cn/edu/nju/cs/itrace4/preprocess/rawdata/db/GenerateRTM.java
+++ b/src/cn/edu/nju/cs/itrace4/preprocess/rawdata/db/GenerateRTM.java
@@ -154,7 +154,7 @@ public class GenerateRTM {
 			if(actualCount<2 && description.length()<8) {
 				continue;
 			}
-			if(request.length()>0) {
+			if(code.length()>0) {
 				request.append(summary+" "+description);
 				request = filter(request.toString().toCharArray());
 				String insertSql = "insert into rtm (request,file_path) values (" + "'" + 

--- a/src/cn/edu/nju/cs/itrace4/relation/RelationInfo.java
+++ b/src/cn/edu/nju/cs/itrace4/relation/RelationInfo.java
@@ -61,7 +61,6 @@ public class RelationInfo implements Serializable {
          
     	
         String callDBPath = relationDirPath + "/call.db";
-        String dataDBPath = relationDirPath + "/call.db";
         this.relationDirPath = relationDirPath;
         this.isPruning = false;
 

--- a/src/cn/edu/nju/cs/tool/test/VisualRelationGraph.java
+++ b/src/cn/edu/nju/cs/tool/test/VisualRelationGraph.java
@@ -118,7 +118,7 @@ public class VisualRelationGraph {
         dataEdges = new LinkedHashMap<>();
         call_data_Edges = new LinkedHashMap<>();
 
-//        this.LAYOUT_FILE = "data/exp/iTrust/relation/PersistentLayoutDemo.out";
+//        this.LAYOUT_FILE = "data/exp/Gantt/relation/PersistentLayoutDemo.out";
         this.LAYOUT_FILE = layoutPath;
 
         edgeFactory = new Factory<Integer>() {
@@ -152,7 +152,7 @@ public class VisualRelationGraph {
         dataEdges = new LinkedHashMap<>();
         call_data_Edges = new LinkedHashMap<>();
 
-//        this.LAYOUT_FILE = "data/exp/iTrust/relation/PersistentLayoutDemo.out";
+//        this.LAYOUT_FILE = "data/exp/Gantt/relation/PersistentLayoutDemo.out";
         this.LAYOUT_FILE = layoutPath;
 
         edgeFactory = new Factory<Integer>() {
@@ -445,24 +445,24 @@ public class VisualRelationGraph {
     }
 
     public static void main(String[] args) throws IOException {
-        String class_relationInfo = "data/exp/iTrust/relation/CLASS_relationInfo_whole.ser";
+        String class_relationInfo = "data/exp/Gantt/relation/CLASS_relationInfo_whole.ser";
 
         try {
             FileInputStream fis = new FileInputStream(class_relationInfo);
             ObjectInputStream ois = new ObjectInputStream(fis);
             RelationInfo ri = (RelationInfo) ois.readObject();
-            ri.setPruning(0.0, 1.5);
+            ri.setPruning(0.6, 0.7);
 
            // System.out.println(ri.getRelationGraphFile());
 
-            String rtmClassPath = "data/exp/iTrust/rtm/RTM_CLASS.txt";
-            String ucPath = "data/exp/iTrust/uc";
-            String classDirPath = "data/exp/iTrust/class/graph/code";
+            String rtmClassPath = "data/exp/Gantt/rtm/RTM_CLASS.txt";
+            String ucPath = "data/exp/Gantt/uc";
+            String classDirPath = "data/exp/Gantt/class/graph/code";
             TextDataset textDataset = new TextDataset(ucPath, classDirPath, rtmClassPath);
             
             
             CallDataRelationGraph cdGraph = new CallDataRelationGraph(ri);
-            String layoutPath = "data/exp/iTrust/relation/PersistentLayoutDemo.out";
+            String layoutPath = "data/exp/Gantt/relation/PersistentLayoutDemo.out";
             VisualRelationGraph visualRelationGraph = new VisualRelationGraph(textDataset, cdGraph, layoutPath);
             visualRelationGraph.show();
 


### PR DESCRIPTION
  1. repair a bug, xx_whole.ser xx.ser, as for **iTrust**、**Gantt** and **jHotDraw** we will generate a new xx_whole.ser but when display we use xx.ser at before. This make preprocess make no effect
    for display for they use **different ser**. Now both preprocess and display use same ser xx_whole.ser.
    2. when we choose a valid region, we calculate the distance from it to others containing valid region and no valid region. The router is all caller or callee. And we find most region has no router to
     specify region for some region maybe *caller callee caller* and this is illegal for us.
